### PR TITLE
chore: remove unnecessary import

### DIFF
--- a/core/src/main/scala/org/apache/pekko/persistence/postgres/journal/dao/JournalDao.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/postgres/journal/dao/JournalDao.scala
@@ -7,7 +7,6 @@ package org.apache.pekko.persistence.postgres.journal.dao
 
 import org.apache.pekko.persistence.AtomicWrite
 
-import scala.collection.immutable.Seq
 import scala.concurrent.Future
 import scala.util.Try
 

--- a/core/src/main/scala/org/apache/pekko/persistence/postgres/journal/dao/package.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/postgres/journal/dao/package.scala
@@ -5,8 +5,6 @@
 
 package org.apache.pekko.persistence.postgres.journal
 
-import scala.collection.immutable.Set
-
 package object dao {
   def encodeTags(tags: Set[String], separator: String): Option[String] =
     if (tags.isEmpty) None else Option(tags.mkString(separator))

--- a/core/src/main/scala/org/apache/pekko/persistence/postgres/query/dao/BaseByteArrayReadJournalDao.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/postgres/query/dao/BaseByteArrayReadJournalDao.scala
@@ -14,9 +14,9 @@ import org.apache.pekko.persistence.postgres.serialization.FlowPersistentReprSer
 import org.apache.pekko.persistence.postgres.tag.TagIdResolver
 import org.apache.pekko.stream.scaladsl.Source
 import slick.basic.DatabasePublisher
-import slick.jdbc.JdbcBackend._
+import slick.jdbc.JdbcBackend.*
 
-import scala.collection.immutable._
+import scala.collection.immutable.*
 import scala.concurrent.Future
 import scala.util.Try
 

--- a/core/src/main/scala/org/apache/pekko/persistence/postgres/query/dao/BaseByteArrayReadJournalDao.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/postgres/query/dao/BaseByteArrayReadJournalDao.scala
@@ -27,7 +27,7 @@ trait BaseByteArrayReadJournalDao extends ReadJournalDao with BaseJournalDaoWith
   def tagIdResolver: TagIdResolver
   def readJournalConfig: ReadJournalConfig
 
-  import org.apache.pekko.persistence.postgres.db.ExtendedPostgresProfile.api._
+  import org.apache.pekko.persistence.postgres.db.ExtendedPostgresProfile.api.*
 
   override def allPersistenceIdsSource(max: Long): Source[String, NotUsed] =
     Source.fromPublisher(db.stream(queries.allPersistenceIdsDistinct(max).result))

--- a/core/src/main/scala/org/apache/pekko/persistence/postgres/query/dao/BaseByteArrayReadJournalDao.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/postgres/query/dao/BaseByteArrayReadJournalDao.scala
@@ -9,21 +9,15 @@ package query.dao
 import org.apache.pekko.NotUsed
 import org.apache.pekko.persistence.PersistentRepr
 import org.apache.pekko.persistence.postgres.config.ReadJournalConfig
-import org.apache.pekko.persistence.postgres.journal.dao.{
-  BaseJournalDaoWithReadMessages,
-  ByteArrayJournalSerializer,
-  JournalMetadataTable
-}
+import org.apache.pekko.persistence.postgres.journal.dao.BaseJournalDaoWithReadMessages
 import org.apache.pekko.persistence.postgres.serialization.FlowPersistentReprSerializer
-import org.apache.pekko.persistence.postgres.tag.{CachedTagIdResolver, SimpleTagDao, TagIdResolver}
-import org.apache.pekko.serialization.Serialization
-import org.apache.pekko.stream.Materializer
+import org.apache.pekko.persistence.postgres.tag.TagIdResolver
 import org.apache.pekko.stream.scaladsl.Source
 import slick.basic.DatabasePublisher
-import slick.jdbc.JdbcBackend.*
+import slick.jdbc.JdbcBackend._
 
-import scala.collection.immutable.*
-import scala.concurrent.{ExecutionContext, Future}
+import scala.collection.immutable._
+import scala.concurrent.Future
 import scala.util.Try
 
 trait BaseByteArrayReadJournalDao extends ReadJournalDao with BaseJournalDaoWithReadMessages {
@@ -33,7 +27,7 @@ trait BaseByteArrayReadJournalDao extends ReadJournalDao with BaseJournalDaoWith
   def tagIdResolver: TagIdResolver
   def readJournalConfig: ReadJournalConfig
 
-  import org.apache.pekko.persistence.postgres.db.ExtendedPostgresProfile.api.*
+  import org.apache.pekko.persistence.postgres.db.ExtendedPostgresProfile.api._
 
   override def allPersistenceIdsSource(max: Long): Source[String, NotUsed] =
     Source.fromPublisher(db.stream(queries.allPersistenceIdsDistinct(max).result))

--- a/core/src/main/scala/org/apache/pekko/persistence/postgres/query/package.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/postgres/query/package.scala
@@ -5,9 +5,7 @@
 
 package org.apache.pekko.persistence.postgres
 
-import org.apache.pekko.NotUsed
-import org.apache.pekko.persistence.query.*
-import org.apache.pekko.stream.scaladsl.Source
+import org.apache.pekko.persistence.query._
 
 import scala.language.implicitConversions
 

--- a/core/src/main/scala/org/apache/pekko/persistence/postgres/query/package.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/postgres/query/package.scala
@@ -5,7 +5,7 @@
 
 package org.apache.pekko.persistence.postgres
 
-import org.apache.pekko.persistence.query._
+import org.apache.pekko.persistence.query.*
 
 import scala.language.implicitConversions
 

--- a/core/src/main/scala/org/apache/pekko/persistence/postgres/snapshot/dao/ByteArraySnapshotDao.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/postgres/snapshot/dao/ByteArraySnapshotDao.scala
@@ -20,7 +20,7 @@ class ByteArraySnapshotDao(db: JdbcBackend#Database, snapshotConfig: SnapshotCon
     ec: ExecutionContext,
     val mat: Materializer
 ) extends SnapshotDao {
-  import org.apache.pekko.persistence.postgres.db.ExtendedPostgresProfile.api._
+  import org.apache.pekko.persistence.postgres.db.ExtendedPostgresProfile.api.*
 
   val queries = new SnapshotQueries(snapshotConfig.snapshotTableConfiguration)
 

--- a/core/src/main/scala/org/apache/pekko/persistence/postgres/snapshot/dao/ByteArraySnapshotDao.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/postgres/snapshot/dao/ByteArraySnapshotDao.scala
@@ -11,7 +11,6 @@ import org.apache.pekko.persistence.postgres.snapshot.dao.SnapshotTables.Snapsho
 import org.apache.pekko.serialization.Serialization
 import org.apache.pekko.stream.Materializer
 import slick.jdbc.JdbcBackend
-import slick.jdbc.JdbcProfile
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success}
@@ -21,7 +20,7 @@ class ByteArraySnapshotDao(db: JdbcBackend#Database, snapshotConfig: SnapshotCon
     ec: ExecutionContext,
     val mat: Materializer
 ) extends SnapshotDao {
-  import org.apache.pekko.persistence.postgres.db.ExtendedPostgresProfile.api.*
+  import org.apache.pekko.persistence.postgres.db.ExtendedPostgresProfile.api._
 
   val queries = new SnapshotQueries(snapshotConfig.snapshotTableConfiguration)
 

--- a/core/src/test/scala/org/apache/pekko/persistence/postgres/query/QueryTestSpec.scala
+++ b/core/src/test/scala/org/apache/pekko/persistence/postgres/query/QueryTestSpec.scala
@@ -8,7 +8,6 @@ package org.apache.pekko.persistence.postgres.query
 import com.typesafe.config.ConfigValue
 import org.apache.pekko.actor.{ActorRef, ActorSystem, Props, Stash, Status}
 import org.apache.pekko.event.LoggingReceive
-import org.apache.pekko.persistence.{DeleteMessagesFailure, DeleteMessagesSuccess, PersistentActor}
 import org.apache.pekko.persistence.journal.Tagged
 import org.apache.pekko.persistence.postgres.SingleActorSystemPerTestSpec
 import org.apache.pekko.persistence.postgres.query.EventAdapterTest.{Event, TaggedAsyncEvent, TaggedEvent}
@@ -16,15 +15,15 @@ import org.apache.pekko.persistence.postgres.query.javadsl.PostgresReadJournal a
 import org.apache.pekko.persistence.postgres.query.scaladsl.PostgresReadJournal
 import org.apache.pekko.persistence.postgres.util.Schema.SchemaType
 import org.apache.pekko.persistence.query.{EventEnvelope, Offset, PersistenceQuery}
-import org.apache.pekko.stream.{Materializer, SystemMaterializer}
+import org.apache.pekko.persistence.{DeleteMessagesFailure, DeleteMessagesSuccess, PersistentActor}
 import org.apache.pekko.stream.scaladsl.Sink
 import org.apache.pekko.stream.testkit.TestSubscriber
 import org.apache.pekko.stream.testkit.javadsl.TestSink as JavaSink
 import org.apache.pekko.stream.testkit.scaladsl.TestSink
-import slick.jdbc.PostgresProfile.api.*
+import org.apache.pekko.stream.{Materializer, SystemMaterializer}
 
 import scala.concurrent.Future
-import scala.concurrent.duration.{FiniteDuration, *}
+import scala.concurrent.duration.{FiniteDuration, _}
 
 trait ReadJournalOperations {
   def withCurrentPersistenceIds(within: FiniteDuration = 60.second)(f: TestSubscriber.Probe[String] => Unit): Unit

--- a/core/src/test/scala/org/apache/pekko/persistence/postgres/query/QueryTestSpec.scala
+++ b/core/src/test/scala/org/apache/pekko/persistence/postgres/query/QueryTestSpec.scala
@@ -8,6 +8,7 @@ package org.apache.pekko.persistence.postgres.query
 import com.typesafe.config.ConfigValue
 import org.apache.pekko.actor.{ActorRef, ActorSystem, Props, Stash, Status}
 import org.apache.pekko.event.LoggingReceive
+import org.apache.pekko.persistence.{DeleteMessagesFailure, DeleteMessagesSuccess, PersistentActor}
 import org.apache.pekko.persistence.journal.Tagged
 import org.apache.pekko.persistence.postgres.SingleActorSystemPerTestSpec
 import org.apache.pekko.persistence.postgres.query.EventAdapterTest.{Event, TaggedAsyncEvent, TaggedEvent}
@@ -15,12 +16,11 @@ import org.apache.pekko.persistence.postgres.query.javadsl.PostgresReadJournal a
 import org.apache.pekko.persistence.postgres.query.scaladsl.PostgresReadJournal
 import org.apache.pekko.persistence.postgres.util.Schema.SchemaType
 import org.apache.pekko.persistence.query.{EventEnvelope, Offset, PersistenceQuery}
-import org.apache.pekko.persistence.{DeleteMessagesFailure, DeleteMessagesSuccess, PersistentActor}
+import org.apache.pekko.stream.{Materializer, SystemMaterializer}
 import org.apache.pekko.stream.scaladsl.Sink
 import org.apache.pekko.stream.testkit.TestSubscriber
 import org.apache.pekko.stream.testkit.javadsl.TestSink as JavaSink
 import org.apache.pekko.stream.testkit.scaladsl.TestSink
-import org.apache.pekko.stream.{Materializer, SystemMaterializer}
 
 import scala.concurrent.Future
 import scala.concurrent.duration.{FiniteDuration, *}

--- a/core/src/test/scala/org/apache/pekko/persistence/postgres/query/QueryTestSpec.scala
+++ b/core/src/test/scala/org/apache/pekko/persistence/postgres/query/QueryTestSpec.scala
@@ -23,7 +23,7 @@ import org.apache.pekko.stream.testkit.scaladsl.TestSink
 import org.apache.pekko.stream.{Materializer, SystemMaterializer}
 
 import scala.concurrent.Future
-import scala.concurrent.duration.{FiniteDuration, _}
+import scala.concurrent.duration.{FiniteDuration, *}
 
 trait ReadJournalOperations {
   def withCurrentPersistenceIds(within: FiniteDuration = 60.second)(f: TestSubscriber.Probe[String] => Unit): Unit


### PR DESCRIPTION
remove some unnecessary import
we not supprot scala 2.12, so we don't need import Seq